### PR TITLE
Allow type overriding

### DIFF
--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -172,7 +172,7 @@ class ArgumentParser(argparse.ArgumentParser):
         for name, field in getattr(self._options_type, "__dataclass_fields__").items():
             args = field.metadata.get("args", [f"--{name.replace('_', '-')}"])
             positional = not args[0].startswith("-")
-            kwargs = {"type": field.type, "help": field.metadata.get("help", None)}
+            kwargs = {"type": field.metadata.get("type", field.type), "help": field.metadata.get("help", None)}
 
             if field.metadata.get("args") and not positional:
                 # We want to ensure that we store the argument based on the

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -111,6 +111,20 @@ Using different flag names and positional arguments:
     >>> print(parser.parse_args(["--long-name", 0, "positional"]))
     Options(x=0, positional='positional')
 
+Using a custom type converter:
+
+.. code-block:: pycon
+
+    >>> from dataclasses import dataclass, field
+    >>> from argparse_dataclass import ArgumentParser
+    >>> @dataclass
+    ... class Options:
+    ...     name: str = field(metadata=dict(type=str.title))
+    ...
+    >>> parser = ArgumentParser(Options)
+    >>> print(parser.parse_args(["--name", "john doe"]))
+    Options(name='John Doe')
+
 License
 -------
 


### PR DESCRIPTION
This PR allows the user to override the `type` argument passed to `add_argument`.
This is useful when a custom function needs to be used, but is not appropriate as a type.
For example, from the [argparse documentation](https://docs.python.org/3/library/argparse.html#type):
```python
def hyphenated(string):
    return '-'.join([word[:4] for word in string.casefold().split()])

parser = argparse.ArgumentParser()
_ = parser.add_argument('short_title', type=hyphenated)
parser.parse_args(['"The Tale of Two Cities"'])
Namespace(short_title='"the-tale-of-two-citi')
```
With this PR, one could define an argument like:
```python
@dataclass
class Options:
    short_title: str = field(metadata=dict(type=hyphenated))
```
And thus the following will work correctly:
```python
parser = argparse_dataclass.ArgumentParser(Options)
parser.parse_args(['--short-title', '"The Tale of Two Cities"'])
```
Which results in `Options(short_title='"the-tale-of-two-citi')`