### PR TITLE
Support nargs

### DIFF
--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -182,6 +182,9 @@ class ArgumentParser(argparse.ArgumentParser):
             if field.metadata.get("choices") is not None:
                 kwargs["choices"] = field.metadata["choices"]
 
+            if field.metadata.get("nargs") is not None:
+                kwargs["nargs"] = field.metadata["nargs"]
+
             if field.default == field.default_factory == MISSING and not positional:
                 kwargs["required"] = True
             else:

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -172,7 +172,7 @@ class ArgumentParser(argparse.ArgumentParser):
         for name, field in getattr(self._options_type, "__dataclass_fields__").items():
             args = field.metadata.get("args", [f"--{name.replace('_', '-')}"])
             positional = not args[0].startswith("-")
-            kwargs = {"type": field.type, "help": field.metadata.get("help", None)}
+            kwargs = {"type": field.metadata.get("type", field.type), "help": field.metadata.get("help", None)}
 
             if field.metadata.get("args") and not positional:
                 # We want to ensure that we store the argument based on the

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -184,6 +184,12 @@ class ArgumentParser(argparse.ArgumentParser):
 
             if field.metadata.get("nargs") is not None:
                 kwargs["nargs"] = field.metadata["nargs"]
+                if field.metadata.get("type") is None:
+                    # When nargs is specified, field.type should be a list,
+                    # or something equivalent, like typing.List.
+                    # Using it would most likely result in an error, so the user
+                    # should specify the type of the elements within the list
+                    raise ValueError("A type must be specified along with nargs")
 
             if field.default == field.default_factory == MISSING and not positional:
                 kwargs["required"] = True

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -141,7 +141,7 @@ SOFTWARE.
 import argparse
 from contextlib import suppress
 from dataclasses import is_dataclass, MISSING, dataclass as real_dataclass
-from typing import TypeVar
+from typing import TypeVar, get_args
 
 __version__ = "0.1.0"
 
@@ -187,9 +187,17 @@ class ArgumentParser(argparse.ArgumentParser):
                 if field.metadata.get("type") is None:
                     # When nargs is specified, field.type should be a list,
                     # or something equivalent, like typing.List.
-                    # Using it would most likely result in an error, so the user
-                    # should specify the type of the elements within the list
-                    raise ValueError("A type must be specified along with nargs")
+                    # Using it would most likely result in an error, so if the user
+                    # did not specify the type of the elements within the list, we
+                    # try to infer it:
+                    try:
+                        kwargs["type"] = get_args(field.type)[0]  # get_args returns a tuple
+                    except IndexError:
+                        # get_args returned an empty tuple, type cannot be inferred
+                        raise ValueError(f"Cannot infer type of items in field: {name}. "
+                                         "Try using a parameterized type hint, or "
+                                         "specifying the type explicitly using "
+                                         "metadata['type']")
 
             if field.default == field.default_factory == MISSING and not positional:
                 kwargs["required"] = True


### PR DESCRIPTION
This PR add support for setting the `nargs` argument passed to `add_argument`.
An example usage of this is as follows:
```python
from dataclasses import dataclass, field
from typing import List
from argparse_dataclass import ArgumentParser

@dataclass
class Options:
    values: List[int] = field(metadata=dict(type=int, nargs='*'))

parser = ArgumentParser(Options)
parser.parse_args('--values 1 2 3'.split())
```
This example results in `Options(values=[1, 2, 3])`

Note that this PR depends on #11
This is because when `nargs` is used, an appropriate field type would be a `list`. However, then `ArgumentParser` will parse each element as a `list`, which is likely an undesired behaviour. Therefore, when `nargs` is specified, it expects `type` to be explicitly specified as well.