### PR TITLE
 Updating type hints so that ArgumentParser.parse_args() returns the correct hint

### DIFF
--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -147,14 +147,14 @@ SOFTWARE.
 import argparse
 from contextlib import suppress
 from dataclasses import is_dataclass, MISSING, dataclass as real_dataclass
-from typing import TypeVar, get_args
+from typing import TypeVar, get_args, Generic, Type
 
 __version__ = "0.1.0"
 
 OptionsType = TypeVar("OptionsType")
 
 
-class ArgumentParser(argparse.ArgumentParser):
+class ArgumentParser(argparse.ArgumentParser, Generic[OptionsType]):
     """Command line argument parser that derives its options from a dataclass.
 
     Parameters
@@ -166,9 +166,9 @@ class ArgumentParser(argparse.ArgumentParser):
 
     """
 
-    def __init__(self, options_class: OptionsType, *args, **kwargs):
+    def __init__(self, options_class: Type[OptionsType], *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._options_type: OptionsType = options_class
+        self._options_type: Type[OptionsType] = options_class
         self._add_dataclass_options()
 
     def _add_dataclass_options(self) -> None:

--- a/tests/test_argumentparser.py
+++ b/tests/test_argumentparser.py
@@ -1,0 +1,25 @@
+import argparse
+import unittest
+from dataclasses import dataclass
+from argparse_dataclass import ArgumentParser
+
+
+@dataclass
+class Opt:
+    x: int = 42
+    y: bool = False
+
+
+class ArgumentParserTests(unittest.TestCase):
+    def test_basic(self):
+        params = ArgumentParser(Opt).parse_args([])
+        self.assertEqual(42, params.x)
+        self.assertEqual(False, params.y)
+        params = ArgumentParser(Opt).parse_args(["--x=10", "--y"])
+        self.assertEqual(10, params.x)
+        self.assertEqual(True, params.y)
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
These are pretty small changes. They have no functional changes. 
This allow VSCode (and probably other IDEs) to detect the dataclass type that is being returned by parse_args().

--- BEFORE -- 
![Before_B1](https://user-images.githubusercontent.com/13785195/118589258-e27e5c80-b754-11eb-9ec5-33c73acdbd32.png)

![Before_B2](https://user-images.githubusercontent.com/13785195/118589284-ef9b4b80-b754-11eb-8846-347ab1af86cb.png)

-- AFTER --
![After_B1](https://user-images.githubusercontent.com/13785195/118589451-4143d600-b755-11eb-8a26-1e81c0593d15.png)

![After_B2](https://user-images.githubusercontent.com/13785195/118589456-456ff380-b755-11eb-9970-1d3ab9aa12a5.png)
