### PR TITLE
Moving _add_dataclass_options() to be a standalone function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jobs:
           env: TOX_ENV=py37
         - python: "3.8"
           env: TOX_ENV=py38
+        - python: "3.9"
+          env: TOX_ENV=py39
 notifications:
     email: false
 install:

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -238,7 +238,7 @@ class ArgumentParser(argparse.ArgumentParser, Generic[OptionsType]):
         return self._options_type(**vars(namespace))
 
 
-def dataclass(cls=None, /, *, init=True, repr=True, eq=True, order=False,
+def dataclass(cls=None, *, init=True, repr=True, eq=True, order=False,
               unsafe_hash=False, frozen=False):
     def wrap(cls):
         cls = real_dataclass(

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -143,11 +143,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 """
-
+import sys
 import argparse
 from contextlib import suppress
 from dataclasses import is_dataclass, fields, MISSING, dataclass as real_dataclass
-from typing import TypeVar, get_args, Generic, Type
+from typing import TypeVar, Generic, Type
+
+if sys.version_info[1] >= 8:
+    # get_args was added in Python 3.8
+    from typing import get_args
+else:
+    def get_args(f: Type) -> tuple:
+        return getattr(f, "__args__", tuple())
+
 
 __version__ = "0.1.0"
 

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -158,7 +158,7 @@ else:
         return getattr(f, "__args__", tuple())
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 OptionsType = TypeVar("OptionsType")
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 black
 flake8
 tox
+pytest

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,6 +1,9 @@
 import sys
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from typing import List
+
 from argparse_dataclass import parse_args
 
 
@@ -67,6 +70,40 @@ class ArgumentParserTests(unittest.TestCase):
             parse_args(Args, [])
             self.assertIsNotNone(helper.exit_status, "Expected an error while parsing")
 
+
+    def test_nargs(self): 
+        @dataclass
+        class Args:
+            name: str
+            friends: List[str] = field(metadata=dict(nargs=2))
+
+        params = parse_args(Args, ["--name", "Sam", "--friends", "pippin", "Frodo"])
+        self.assertEqual("Sam", params.name)
+        self.assertEqual([ "pippin", "Frodo"], params.friends)
+
+    def test_nargs_plus(self): 
+        @dataclass
+        class Args:
+            name: str
+            friends: List[str] = field(metadata=dict(nargs="+"))
+
+        args = ["--name", "Sam", "--friends", "pippin", "Frodo"]
+        params = parse_args(Args, args)
+        self.assertEqual("Sam", params.name)
+        self.assertEqual(["pippin", "Frodo"], params.friends)
+        
+        args += ["Bilbo"]
+        params = parse_args(Args, args)
+        self.assertEqual("Sam", params.name)
+        self.assertEqual(["pippin", "Frodo", "Bilbo"], params.friends)
+
+
+    def test_nargs_negative(self):
+        @dataclass
+        class Args:
+            name: str
+            friends: list = field(metadata=dict(nargs=2))
+        self.assertRaises(ValueError, parse_args, Args, ["--name", "Sam", "--friends", "pippin", "Frodo"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,72 @@
+import sys
+import unittest
+from dataclasses import dataclass
+from argparse_dataclass import parse_args
+
+
+class NegativeTestHelper:
+    ''' Helper to enable testing of negative test cases. 
+        On error parse_args() will call sys.exit(). 
+        this will hijack that call and log the status code.
+    '''
+    def __init__(self):
+        self._sys_exit = None
+        self.exit_status: int = None
+
+    def _on_exit(self, status: int):
+        self.exit_status = status
+
+    def __enter__(self):
+        self._sys_exit = sys.exit
+        sys.exit = self._on_exit
+        return self
+
+    def __exit__(self, *args, **kargs):
+        sys.exit = self._sys_exit
+
+
+class ArgumentParserTests(unittest.TestCase):
+    def test_basic(self):
+        @dataclass
+        class Opt:
+            x: int = 42
+            y: bool = False
+        params = parse_args(Opt, [])
+        self.assertEqual(42, params.x)
+        self.assertEqual(False, params.y)
+        params = parse_args(Opt, ["--x=10", "--y"])
+        self.assertEqual(10, params.x)
+        self.assertEqual(True, params.y)
+
+    
+    def test_basic_negative(self):
+        class Opt:
+            x: int = 42
+            y: bool = False
+        self.assertRaises(TypeError, parse_args, Opt, [])
+
+        
+    def test_no_defaults(self): 
+        @dataclass
+        class Args:
+            num_of_foo: int
+            name: str
+
+        params = parse_args(Args, ["--num-of-foo=10", "--name", "Sam"])
+        self.assertEqual(10, params.num_of_foo)
+        self.assertEqual("Sam", params.name)
+
+
+    def test_no_defaults_negative(self):
+        @dataclass
+        class Args:
+            num_of_foo: int
+            name: str
+
+        with NegativeTestHelper() as helper:
+            parse_args(Args, [])
+            self.assertIsNotNone(helper.exit_status, "Expected an error while parsing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38
+envlist = py36, py37, py38, py39
 # isolated_build = True
 
 [testenv]
@@ -7,5 +7,6 @@ deps =
     -r {toxinidir}/requirements_dev.txt
 commands =
     python -m doctest argparse_dataclass.py
+    pytest
 commands_post =
     black --check argparse_dataclass.py


### PR DESCRIPTION
This might be a more controversial change. 😄 I was looking at the new dataclass decorator overload that was implemented. It is a nice concept except that type hinting does not work with it. Since type hinting is the main benefit over normal argparse (In my opinion) I came up with this other approach. 

Not sure how much approach conflicts with your vision of what you want but it seems to offer a similar experience as the dataclass approach while maintaining type hints. 