### PR TITLE
Added URL to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    url="https://github.com/mivade/argparse_dataclass",
 )


### PR DESCRIPTION
This should display the URL at https://pypi.org/project/argparse-dataclass/ and make the project more discoverable.