### PR TITLE
Support Literal types as an alternative means of specifying choices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,9 +77,10 @@ Enabling choices for an option:
 
     >>> from dataclasses import dataclass, field
     >>> from argparse_dataclass import ArgumentParser
+    >>> from typing import Literal
     >>> @dataclass
     ... class Options:
-    ...     small_integer: int = field(metadata=dict(choices=[1, 2, 3]))
+    ...     small_integer: Literal[1,2,3]
     ...
     >>> parser = ArgumentParser(Options)
     >>> print(parser.parse_args(["--small-integer", "3"]))

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -338,7 +338,15 @@ def _add_dataclass_options(
             kwargs["choices"] = field.metadata["choices"]
 
         # Support Literal types as an alternative means of specifying choices.
-        elif typing.get_origin(field.type) is typing.Literal:
+        if typing.get_origin(field.type) is typing.Literal:
+
+            # Prohibit a potential collision with the choices field
+            if field.metadata.get("choices") is not None:
+                raise ValueError(
+                        f"Cannot infer type of items in field: {field.name}. "
+                        "Literal type arguments should not be combined with choices in the metadata. "
+                        "Remove the redundant choices field from the metadata."
+                )
 
             # Get the types of the arguments of the Literal
             types = [type(arg) for arg in typing.get_args(field.type)]

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -337,6 +337,25 @@ def _add_dataclass_options(
         if field.metadata.get("choices") is not None:
             kwargs["choices"] = field.metadata["choices"]
 
+        # Support Literal types as an alternative means of specifying choices.
+        elif typing.get_origin(field.type) is typing.Literal:
+
+            # Get the types of the arguments of the Literal
+            types = [type(arg) for arg in typing.get_args(field.type)]
+
+            # Make sure just a single type has been used
+            if len(set(types)) > 1:
+                raise ValueError(
+                        f"Cannot infer type of items in field: {field.name}. "
+                        "Literal type arguments should contain choices of a single type. "
+                        f"Instead, {len(set(types))} types where found: "+ ", ".join([type_.__name__ for type_ in set(types)]) + "."
+                )
+            
+            # Overwrite the type kwarg
+            kwargs["type"] = types[0]
+            # Use the literal arguments as choices
+            kwargs["choices"] = typing.get_args(field.type)
+
         if field.metadata.get("metavar") is not None:
             kwargs["metavar"] = field.metadata["metavar"]
 

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -340,7 +340,6 @@ def _add_dataclass_options(
 
         # Support Literal types as an alternative means of specifying choices.
         if typing.get_origin(field.type) is typing.Literal:
-
             # Prohibit a potential collision with the choices field
             if field.metadata.get("choices") is not None:
                 raise ValueError(

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -343,9 +343,9 @@ def _add_dataclass_options(
             # Prohibit a potential collision with the choices field
             if field.metadata.get("choices") is not None:
                 raise ValueError(
-                        f"Cannot infer type of items in field: {field.name}. "
-                        "Literal type arguments should not be combined with choices in the metadata. "
-                        "Remove the redundant choices field from the metadata."
+                    f"Cannot infer type of items in field: {field.name}. "
+                    "Literal type arguments should not be combined with choices in the metadata. "
+                    "Remove the redundant choices field from the metadata."
                 )
 
             # Get the types of the arguments of the Literal
@@ -354,11 +354,13 @@ def _add_dataclass_options(
             # Make sure just a single type has been used
             if len(set(types)) > 1:
                 raise ValueError(
-                        f"Cannot infer type of items in field: {field.name}. "
-                        "Literal type arguments should contain choices of a single type. "
-                        f"Instead, {len(set(types))} types where found: "+ ", ".join([type_.__name__ for type_ in set(types)]) + "."
+                    f"Cannot infer type of items in field: {field.name}. "
+                    "Literal type arguments should contain choices of a single type. "
+                    f"Instead, {len(set(types))} types where found: "
+                    + ", ".join([type_.__name__ for type_ in set(types)])
+                    + "."
                 )
-            
+
             # Overwrite the type kwarg
             kwargs["type"] = types[0]
             # Use the literal arguments as choices

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -78,6 +78,7 @@ Enabling choices for an option:
 
     >>> from dataclasses import dataclass, field
     >>> from argparse_dataclass import ArgumentParser
+    >>> from typing import Literal
     >>> @dataclass
     ... class Options:
     ...     small_integer: Literal[1, 2, 3]

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -80,7 +80,7 @@ Enabling choices for an option:
     >>> from argparse_dataclass import ArgumentParser
     >>> @dataclass
     ... class Options:
-    ...     small_integer: int = field(metadata=dict(choices=[1, 2, 3]))
+    ...     small_integer: Literal[1, 2, 3]
     ...
     >>> parser = ArgumentParser(Options)
     >>> print(parser.parse_args(["--small-integer", "3"]))

--- a/tests/example_choices.py
+++ b/tests/example_choices.py
@@ -7,7 +7,7 @@ from typing import Literal
 class Opt:
     x: int = 42
     y: bool = False
-    z: Literal['a', 'b'] = 'a'
+    z: Literal["a", "b"] = "a"
 
 
 def main():

--- a/tests/example_choices.py
+++ b/tests/example_choices.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from argparse_dataclass import dataclass
+from typing import Literal
+
+
+@dataclass
+class Opt:
+    x: int = 42
+    y: bool = False
+    z: Literal['a', 'b'] = 'a'
+
+
+def main():
+    params = Opt.parse_args()
+    print(params)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_argumentparser.py
+++ b/tests/test_argumentparser.py
@@ -256,14 +256,13 @@ class ArgumentParserTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             ArgumentParser(Options).parse_args(args)
 
-
     def test_literal(self):
         """Test case for basic usage of a Literal type for providing choices."""
 
         @dataclass
         class Options:
             a_or_b: Literal["a", "b"]
-        
+
         # Provide a valid argument
         args = ["--a-or-b", "a"]
         params = ArgumentParser(Options).parse_args(args)
@@ -275,7 +274,7 @@ class ArgumentParserTests(unittest.TestCase):
         @dataclass
         class Options:
             a_or_b: Literal["a", "b"]
-        
+
         # Provide an invalid argument
         args = ["--a-or-b", "c"]
         with NegativeTestHelper() as helper:
@@ -299,9 +298,10 @@ class ArgumentParserTests(unittest.TestCase):
         # Provide a Literal type combined with choices in the meta field
         @dataclass
         class Options:
-            a_or_3: Literal["a", "b"] = field(metadata={'choices' : ["a", "b"]})
+            a_or_3: Literal["a", "b"] = field(metadata={"choices": ["a", "b"]})
 
         self.assertRaises(ValueError, lambda: ArgumentParser(Options))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_argumentparser.py
+++ b/tests/test_argumentparser.py
@@ -3,7 +3,7 @@ import unittest
 import datetime as dt
 from dataclasses import dataclass, field
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Literal
 from argparse_dataclass import ArgumentParser
 
 
@@ -256,6 +256,42 @@ class ArgumentParserTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             ArgumentParser(Options).parse_args(args)
 
+
+    def test_literal(self):
+        """Test case for basic usage of a Literal type for providing choices."""
+
+        @dataclass
+        class Options:
+            a_or_b: Literal["a", "b"]
+        
+        # Provide a valid argument
+        args = ["--a-or-b", "a"]
+        params = ArgumentParser(Options).parse_args(args)
+        self.assertEqual(params.a_or_b, "a")
+
+    def test_literal_invalid_argument(self):
+        """Test case for the Literal type: show that incorrect arguments fail on parsing."""
+
+        @dataclass
+        class Options:
+            a_or_b: Literal["a", "b"]
+        
+        # Provide an invalid argument
+        args = ["--a-or-b", "c"]
+        with NegativeTestHelper() as helper:
+            ArgumentParser(Options).parse_args(args)
+
+        self.assertIsNotNone(helper.exit_status, "Expected an error while parsing")
+
+    def test_literal_mixed_types(self):
+        """Test case for the Literal type: show that using a Literal with mixed arguments is rejected with a ValueError."""
+
+        # Provide a Literal type with mixed argument types
+        @dataclass
+        class Options:
+            a_or_3: Literal["a", 3]
+
+        self.assertRaises(ValueError, lambda: ArgumentParser(Options))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_argumentparser.py
+++ b/tests/test_argumentparser.py
@@ -293,5 +293,15 @@ class ArgumentParserTests(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: ArgumentParser(Options))
 
+    def test_literal_choices_collision(self):
+        """Test case for the Literal type: do not allow choices in the metadata when the field type is Literal."""
+
+        # Provide a Literal type combined with choices in the meta field
+        @dataclass
+        class Options:
+            a_or_3: Literal["a", "b"] = field(metadata={'choices' : ["a", "b"]})
+
+        self.assertRaises(ValueError, lambda: ArgumentParser(Options))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds support for using a `Literal` type to specify a fixed number of argument choices. This feature is intended as a improvement over the use of the `choices` field of the `metadata`.

### Example usage
```py
from argparse_dataclass import dataclass
from typing import Literal


@dataclass
class Opt:
    z: Literal['a', 'b'] = 'a'


def main():
    params = Opt.parse_args()
    print(params)


if __name__ == "__main__":
    main()
```

### Rationale
Specifying choices using a type rather than via the metadata field has two advantages.
1. Using native Python functionality reduces the need of learning/looking up the options that this specific module provides. This improves readability and usability.
2. Using a `Literal` type instead of a more generic type (`int`, `float`, `str`) for a limit set of options narrows the type specification and makes optimum use of the functionality of type checkers such as mypy.

### Considerations
1. The `Literal` type is supported from Python 3.8. As dropping support for earlier versions of Python is already anticipated on in #39, no time was spend on testing this in older Python versions.
2. The use of `metadata['choices']` is still possible and has precedence over the use of the `Literal` type.

### Content of PR
1. Support for `Literal` type added to `argparse_dataclass._add_dataclass_options()`
2. Test cases added to `tests/test_argumentparser.py`
3. Update `README.rst` on the use of choices.



P.S. Thank you very much for developing and sharing this highly useful module! Highly appreciated. 