### PR TITLE
Update CI status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 Declarative CLIs with ``argparse`` and ``dataclasses``.
 
 .. image:: https://github.com/mivade/argparse_dataclass/actions/workflows/main.yml/badge.svg
-    :target:
+    :target: https://github.com/mivade/argparse_dataclass/actions
     :alt: GitHub Actions status
 .. image:: https://img.shields.io/pypi/v/argparse_dataclass
     :alt: PyPI

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@
 
 Declarative CLIs with ``argparse`` and ``dataclasses``.
 
-.. image:: https://travis-ci.org/mivade/argparse_dataclass.svg?branch=master
-    :target: https://travis-ci.org/mivade/argparse_dataclass
-
+.. image:: https://github.com/mivade/argparse_dataclass/actions/workflows/main.yml/badge.svg
+    :target:
+    :alt: GitHub Actions status
 .. image:: https://img.shields.io/pypi/v/argparse_dataclass
     :alt: PyPI
 

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -5,7 +5,7 @@
 Declarative CLIs with ``argparse`` and ``dataclasses``.
 
 .. image:: https://github.com/mivade/argparse_dataclass/actions/workflows/main.yml/badge.svg
-    :target:
+    :target: https://github.com/mivade/argparse_dataclass/actions
     :alt: GitHub Actions status
 .. image:: https://img.shields.io/pypi/v/argparse_dataclass
     :alt: PyPI

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -4,9 +4,9 @@
 
 Declarative CLIs with ``argparse`` and ``dataclasses``.
 
-.. image:: https://travis-ci.org/mivade/argparse_dataclass.svg?branch=master
-    :target: https://travis-ci.org/mivade/argparse_dataclass
-
+.. image:: https://github.com/mivade/argparse_dataclass/actions/workflows/main.yml/badge.svg
+    :target:
+    :alt: GitHub Actions status
 .. image:: https://img.shields.io/pypi/v/argparse_dataclass
     :alt: PyPI
 


### PR DESCRIPTION
Point to GitHub Actions instead of the old Travis CI setup.

Closes #22.