### PR TITLE
Bug/issue 54 update manifest include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - Unreleased
+
+### Fixed
+* Update `MANIFEST.in` file when building source distributions
+
 ## [2.0.0] - 2023-06-11
 ### Added
 * Support for using `metavar` in field metadata (#44)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
-README.rst
-LICENSE
-requirements_dev.txt
-tox.ini
+include README.rst
+include LICENSE
+include requirements_dev.txt
+include tox.ini
+include Makefile

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -298,7 +298,7 @@ else:
 # In Python 3.10, we can use types.NoneType
 NoneType = type(None)
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 OptionsType = TypeVar("OptionsType")
 ArgsType = Optional[Sequence[str]]


### PR DESCRIPTION
# Summary

This PR responds to isssue #54 concerning the updating of the `MANIFEST.in` file. 

# Issues Addressed

+ https://github.com/mivade/argparse_dataclass/issues/54

# Changes Made

1. Update `MANIFEST.in` file to use the `include` statement
2. Specify the following files in `MANIFEST` for inclusion in source distributions
  + `README.rst`
  + `LICENSE`
  + `requirements_dev.txt`
  + `tox.ini`
  + `Makefile`
3. Update the patch version to `1` and the full version from `2.0.0` to `2.0.1`
4. Update `CHANGELOG.md` with information about an `unreleased` version 2.0.1 as per [comments in a previous PR](https://github.com/mivade/argparse_dataclass/pull/50#discussion_r1219845348)

# Considerations

+ What are your thoughts about including the `CHANGELOG.md` in the `MANIFEST`? I am in favor of including the file but am not married to the decision. The standard for what is included in the `MANIFEST` file. Notable packages that include a changelog of some sort are:
  - [requests](https://github.com/psf/requests/tree/main)
  - [numpy](https://github.com/numpy/numpy) - as part of the `docs/` folder. 
  - [six](https://github.com/benjaminp/six)
+ Notable packages that do **not** include the some sort of changelog in their `MANIFEST` files:
  - [boto3](https://github.com/boto/boto3)

# References

+ [Including files in source distributions with MANIFEST.in](https://packaging.python.org/en/latest/guides/using-manifest-in/)
+ [PyPi download statistics aggregator. I used this page to quickly access popular PyPi packages to examine their `MAINFEST.in` patterns](https://pypistats.org/top)
+ [`requests` MANIFEST file](https://github.com/psf/requests/blob/main/MANIFEST.in)
+ [`numpy` MANIFEST file](https://github.com/numpy/numpy/blob/main/MANIFEST.in)
+ [`six` MANIFEST file](https://github.com/benjaminp/six/blob/master/MANIFEST.in)
+ [`boto3` MANIFEST file](https://github.com/boto/boto3/blob/develop/MANIFEST.in)

# Other

Always a pleasure to work with you on this package! :) 