### PR TITLE
Making add dataclass options public

### DIFF
--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -359,7 +359,7 @@ def add_dataclass_options(
         if field.default == field.default_factory == MISSING and not positional:
             kwargs["required"] = True
         else:
-            kwargs["default"] = MISSING
+            kwargs["default"] = field.default
 
         if field.type is bool:
             _handle_bool_type(field, args, kwargs)

--- a/argparse_dataclass.py
+++ b/argparse_dataclass.py
@@ -298,7 +298,7 @@ def parse_args(
 ) -> OptionsType:
     """Parse arguments and return as the dataclass type."""
     parser = argparse.ArgumentParser()
-    _add_dataclass_options(options_class, parser)
+    add_dataclass_options(options_class, parser)
     kwargs = _get_kwargs(parser.parse_args(args))
     return options_class(**kwargs)
 
@@ -310,13 +310,13 @@ def parse_known_args(
     and list of remaining arguments.
     """
     parser = argparse.ArgumentParser()
-    _add_dataclass_options(options_class, parser)
+    add_dataclass_options(options_class, parser)
     namespace, others = parser.parse_known_args(args=args)
     kwargs = _get_kwargs(namespace)
     return options_class(**kwargs), others
 
 
-def _add_dataclass_options(
+def add_dataclass_options(
     options_class: typing.Type[OptionsType], parser: argparse.ArgumentParser
 ) -> None:
     if not is_dataclass(options_class):
@@ -420,7 +420,7 @@ class ArgumentParser(argparse.ArgumentParser, typing.Generic[OptionsType]):
     def __init__(self, options_class: typing.Type[OptionsType], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._options_type: typing.Type[OptionsType] = options_class
-        _add_dataclass_options(options_class, self)
+        add_dataclass_options(options_class, self)
 
     def parse_args(self, args: ArgsType = None, namespace=None) -> OptionsType:
         """Parse arguments and return as the dataclass type."""

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import unittest
 import datetime as dt
@@ -5,7 +6,7 @@ from dataclasses import dataclass, field
 
 from typing import List, Optional, Union
 
-from argparse_dataclass import parse_args, parse_known_args
+from argparse_dataclass import add_dataclass_options, parse_args, parse_known_args
 
 
 class NegativeTestHelper:
@@ -59,8 +60,9 @@ class FunctionalParserTests(unittest.TestCase):
             x: int = 42
             y: bool = False
         argpument_parser = argparse.ArgumentParser()
-        add_dataclass_options(argpument_parser, Opt)
-        params = argpument_parser.parse_args()
+        add_dataclass_options(Opt, argpument_parser)
+        params = argpument_parser.parse_args([])
+        print(params)
         self.assertEqual(42, params.x)
         self.assertEqual(False, params.y)
         params = params = argpument_parser.parse_args(["--x=10", "--y"])

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -53,6 +53,20 @@ class FunctionalParserTests(unittest.TestCase):
 
         self.assertRaises(TypeError, parse_args, Opt, [])
 
+    def test_add_dataclass_options(self):
+        @dataclass
+        class Opt:
+            x: int = 42
+            y: bool = False
+        argpument_parser = argparse.ArgumentParser()
+        add_dataclass_options(argpument_parser, Opt)
+        params = argpument_parser.parse_args()
+        self.assertEqual(42, params.x)
+        self.assertEqual(False, params.y)
+        params = params = argpument_parser.parse_args(["--x=10", "--y"])
+        self.assertEqual(10, params.x)
+        self.assertEqual(True, params.y)
+        
     def test_bool_no_default(self):
         @dataclass
         class Opt:


### PR DESCRIPTION
draft PR to solve https://github.com/mivade/argparse_dataclass/issues/58
I wrote this before realizing there was another PR to fix the same issue    [here](https://github.com/mivade/argparse_dataclass/pull/59)

Note that I had to use  `kwargs["default"] = field.default` for the test to pass. I did not read the code in enough detail to have confidence that it is the right fix.

