### PR TITLE
Improve flake8 support - make it compatible with black

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,5 +33,8 @@ jobs:
           pip3 --version
           pip3 install setuptools tox
 
-      - name: Run tox
+      - name: Run pytest
         run: tox -e py
+
+      - name: Run flake8
+        run: tox -e flake8

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README.rst
 include LICENSE
-include requirements_dev.txt
 include tox.ini
 include Makefile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 Homepage = "https://github.com/mivade/argparse_dataclass"
 
 [project.optional-dependencies]
-dev = ["black", "flake8", "tox", "pytest", "build"]
+dev = ["black", "flake8", "flake8-pyproject", "tox", "pytest", "build"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,9 @@ dev = ["black", "flake8", "flake8-pyproject", "tox", "pytest", "build"]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.flake8]
+# Recommended by black
+max-line-length = 88
+extend-ignore = [
+    "E501", # line too long, even for constants - incompatible with black
+]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,0 @@
-black
-flake8
-tox
-pytest
-build

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,6 @@ extras = dev
 commands =
     python -m doctest argparse_dataclass.py
     pytest
-commands_post =
-    black --check argparse_dataclass.py
-    black --check tests
+
+[testenv:flake8]
+commands = flake8 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ envlist = py39, py310, py311, py312, py313
 # isolated_build = True
 
 [testenv]
-deps =
-    -r {toxinidir}/requirements_dev.txt
+extras = dev
 commands =
     python -m doctest argparse_dataclass.py
     pytest


### PR DESCRIPTION
Currently a lot of warnings are shows when opening the source with vscode and the flake8 plugin enabled.

Fix this by adding flake8-pyproject and explicitly ignore E501. Also add flake8 to tox and github actions to ensure the project has no flake8 issues in the future.